### PR TITLE
Loki 0.4.0 compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import logging_loki
 
 
 handler = logging_loki.LokiHandler(
-    url="https://my-loki-instance/api/prom/push", 
+    url="https://my-loki-instance/loki/api/v1/push", 
     tags={"application": "my-app"},
     auth=("username", "password"),    
 )
@@ -54,7 +54,7 @@ from queue import Queue
 queue = Queue(-1)
 handler = logging.handlers.QueueHandler(queue)
 handler_loki = logging_loki.LokiHandler(
-    url="https://my-loki-instance/api/prom/push", 
+    url="https://my-loki-instance/loki/api/v1/push", 
     tags={"application": "my-app"},
     auth=("username", "password"),    
 )
@@ -75,7 +75,7 @@ from queue import Queue
 
 handler = logging_loki.LokiQueueHandler(
     Queue(-1),
-    url="https://my-loki-instance/api/prom/push", 
+    url="https://my-loki-instance/loki/api/v1/push", 
     tags={"application": "my-app"},
     auth=("username", "password"),
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     url="https://github.com/greyzmeem/python-logging-loki",
     packages=setuptools.find_packages(),
     python_requires=">=3.5",
-    install_requires=["rfc3339>=6.1", "requests"],
+    install_requires=["requests"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Loki 0.4.0 deprecated the older push endpoint, newer one is a bit simpler to use. This PR would be incompatible older loki versions as is.