### PR TITLE
#7 Emitter raises TypeError when trying to build tags

### DIFF
--- a/logging_loki/emitter.py
+++ b/logging_loki/emitter.py
@@ -5,6 +5,7 @@ import copy
 import functools
 import logging
 import time
+from logging.config import ConvertingDict
 from typing import Any
 from typing import Dict
 from typing import List
@@ -87,7 +88,8 @@ class LokiEmitter(abc.ABC):
 
     def build_tags(self, record: logging.LogRecord) -> Dict[str, Any]:
         """Return tags that must be send to Loki with a log record."""
-        tags = copy.deepcopy(self.tags)
+        tags = dict(self.tags) if isinstance(self.tags, ConvertingDict) else self.tags
+        tags = copy.deepcopy(tags)
         tags[self.level_tag] = record.levelname.lower()
         tags[self.logger_tag] = record.name
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ max-imports = 15
 exclude =
     .tox
     logging_loki/__init__.py
-ignore = D100,D104
+ignore = D100,D104,DAR
 per-file-ignores =
     logging_loki/const.py:WPS226
     tests/*:D,S101,WPS118,WPS202,WPS204,WPS210,WPS226,WPS442

--- a/tests/test_emitter_v0.py
+++ b/tests/test_emitter_v0.py
@@ -2,6 +2,8 @@
 
 import logging
 import time
+from logging.config import dictConfig as loggingDictConfig
+from queue import Queue
 from typing import Tuple
 from unittest.mock import MagicMock
 
@@ -156,3 +158,26 @@ def test_session_is_closed(emitter_v0):
     emitter.close()
     session().close.assert_called_once()
     assert emitter._session is None  # noqa: WPS437
+
+
+def test_can_build_tags_from_converting_dict(emitter_v0):
+    logger_name = "converting_dict_tags_v0"
+    config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {
+            logger_name: {
+                "class": "logging_loki.LokiQueueHandler",
+                "queue": Queue(-1),
+                "url": emitter_url,
+                "tags": {"test": "test"},
+                "version": "0",
+            },
+        },
+        "loggers": {logger_name: {"handlers": [logger_name], "level": "DEBUG"}},
+    }
+    loggingDictConfig(config)
+
+    logger = logging.getLogger(logger_name)
+    emitter: LokiEmitterV0 = logger.handlers[0].handler.emitter
+    emitter.build_tags(create_record())


### PR DESCRIPTION
Explicitly cast `ConvertingDict` to `dict` before performing deepcopy of tags. 
Closes #7 
