### PR TITLE
Add support to pass headers sent with each POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ import logging_loki
 handler = logging_loki.LokiHandler(
     url="https://my-loki-instance/loki/api/v1/push", 
     tags={"application": "my-app"},
+    headers={"X-Scope-OrgID": "example-id"},
     auth=("username", "password"),
     version="1",
 )
@@ -58,6 +59,7 @@ handler = logging.handlers.QueueHandler(queue)
 handler_loki = logging_loki.LokiHandler(
     url="https://my-loki-instance/loki/api/v1/push", 
     tags={"application": "my-app"},
+    headers={"X-Scope-OrgID": "example-id"},
     auth=("username", "password"),
     version="1",
 )

--- a/logging_loki/emitter.py
+++ b/logging_loki/emitter.py
@@ -30,7 +30,7 @@ class LokiEmitter(abc.ABC):
     label_replace_with = const.label_replace_with
     session_class = requests.Session
 
-    def __init__(self, url: str, tags: Optional[dict] = None, auth: BasicAuth = None):
+    def __init__(self, url: str, tags: Optional[dict] = None, headers: Optional[dict] = None, auth: BasicAuth = None):
         """
         Create new Loki emitter.
 
@@ -42,6 +42,8 @@ class LokiEmitter(abc.ABC):
         """
         #: Tags that will be added to all records handled by this handler.
         self.tags = tags or {}
+        #: Headers that will be added to all requests handled by this emitter.
+        self.headers = headers or {}
         #: Loki JSON push endpoint (e.g `http://127.0.0.1/loki/api/v1/push`)
         self.url = url
         #: Optional tuple with username and password for basic authentication.
@@ -52,7 +54,7 @@ class LokiEmitter(abc.ABC):
     def __call__(self, record: logging.LogRecord, line: str):
         """Send log record to Loki."""
         payload = self.build_payload(record, line)
-        resp = self.session.post(self.url, json=payload)
+        resp = self.session.post(self.url, json=payload, headers=self.headers)
         if resp.status_code != self.success_response_code:
             raise ValueError("Unexpected Loki API response status code: {0}".format(resp.status_code))
 

--- a/logging_loki/handlers.py
+++ b/logging_loki/handlers.py
@@ -40,6 +40,7 @@ class LokiHandler(logging.Handler):
         self,
         url: str,
         tags: Optional[dict] = None,
+        headers: Optional[dict] = None,
         auth: Optional[emitter.BasicAuth] = None,
         version: Optional[str] = None,
     ):
@@ -67,7 +68,7 @@ class LokiHandler(logging.Handler):
         version = version or const.emitter_ver
         if version not in self.emitters:
             raise ValueError("Unknown emitter version: {0}".format(version))
-        self.emitter = self.emitters[version](url, tags, auth)
+        self.emitter = self.emitters[version](url, tags, headers, auth)
 
     def handleError(self, record):  # noqa: N802
         """Close emitter and let default handler take actions on error."""


### PR DESCRIPTION
FIrst, thanks for implementing python-logging-loki!

We want to adopt this library but our Loki instance requires `X-Scope-OrgID` header to be sent with each request. This pull request adds the capability to do so when configuring the handler.