### PR TITLE
Optionally sends entire record as JSON instead of only message

### DIFF
--- a/logging_loki/handlers.py
+++ b/logging_loki/handlers.py
@@ -42,6 +42,7 @@ class LokiHandler(logging.Handler):
         tags: Optional[dict] = None,
         auth: Optional[emitter.BasicAuth] = None,
         version: Optional[str] = None,
+        as_json: Optional[bool] = False
     ):
         """
         Create new Loki logging handler.
@@ -67,7 +68,7 @@ class LokiHandler(logging.Handler):
         version = version or const.emitter_ver
         if version not in self.emitters:
             raise ValueError("Unknown emitter version: {0}".format(version))
-        self.emitter = self.emitters[version](url, tags, auth)
+        self.emitter = self.emitters[version](url, tags, auth, as_json)
 
     def handleError(self, record):  # noqa: N802
         """Close emitter and let default handler take actions on error."""


### PR DESCRIPTION
A new flag to send entire record object as a JSON so Grafana can show more info

On dashboard
![image](https://user-images.githubusercontent.com/57471416/196720554-bc9c9eff-fe4b-4e62-a53a-82cb83a21581.png)

When click a message
![image](https://user-images.githubusercontent.com/57471416/196720122-41edbf05-df0e-446e-8f72-22135f98b848.png)

Query options:
![image](https://user-images.githubusercontent.com/57471416/196720274-1be86d70-83eb-4a77-9244-da57801d642c.png)
