### PR TITLE
Add support for adding callables as extra tags and some major improvements

### DIFF
--- a/tests/test_emitter_v1.py
+++ b/tests/test_emitter_v1.py
@@ -176,3 +176,4 @@ def test_can_build_tags_from_converting_dict(emitter_v1):
     logger = logging.getLogger(logger_name)
     emitter: LokiEmitterV1 = logger.handlers[0].handler.emitter
     emitter.build_tags(create_record())
+    payload = emitter.build_payload(create_record(), 10)

--- a/tests/test_real_logs.py
+++ b/tests/test_real_logs.py
@@ -1,0 +1,54 @@
+import logging
+import time
+
+import logging_loki
+from logging_loki.emitter import LokiEmitterV1
+
+
+def test_callable_tags():
+    class MyEmitter(LokiEmitterV1):
+
+        def build_payload(self, record, line) -> dict:
+            labels = self.build_tags(record)
+            ns = 1e9
+            ts = str(int(time.time() * ns))
+            stream = {
+                "stream": labels,
+                "values": [[ts, line, self.get_entry_labels(record, line)]],
+            }
+            return {"streams": [stream]}
+
+        def __call__(self, record, line_no):
+            payload = self.build_payload(record, line_no)
+            stream = payload['streams'][0]['values'][0][2]
+            assert 'application' in stream
+            assert stream['value'] == 5
+            assert stream['device'] == 'test'
+            assert stream['levelname'] == 'WARNING'
+
+    # Register a mock emitter
+    logging_loki.LokiHandler.emitters['mock_emitter'] = MyEmitter
+
+    handler = logging_loki.LokiHandler(
+        url="https://example.com/loki/api/v1/push",
+        tags={"application": "my-app", 'value': lambda: 5},
+        auth=("username", "password"),
+        version="mock_emitter"
+    )
+    logger = logging.getLogger("my-logger")
+    logger.addHandler(handler)
+    logger.warning('Error occurred', extra={'tags': {'device': 'test'}})
+    logger.warning('Error occurred', extra={'device': 'test'})
+
+
+def test_not_support_v0():
+    try:
+        logging_loki.LokiHandler(
+            url="https://example.com/loki/api/v1/push",
+            tags={"application": "my-app", 'value': lambda: 5},
+            auth=("username", "password"),
+            version="0")
+    except ValueError:
+        pass
+    else:
+        assert False, 'V0 supports callable labels'


### PR DESCRIPTION
Support was added for specifying callables as extra fields. This is super useful if we're trying to attach span_id and trace_id to a log entry in order to cross-match it with a tracing system, such as Jaeger, and we need that data dynamically rather than statically at startup.

Example:
```python
get_context = lambda: tracer.active_span.context
add_trace_id = lambda: hex(get_context().trace_id)[2:] if tracer is not None and tracer.active_span is not None else None
add_span_id = lambda: hex(get_context().span_id)[2:] if tracer is not None and tracer.active_span else None

handler = logging_loki.LokiQueueHandler(
    Queue(-1),
    url="https://my-loki-instance/loki/api/v1/push", 
    tags={"application": "my-app", 'span_id': add_span_id, 'trace_id': add_trace_id},
    auth=("username", "password"),
    version="1"
)
```

As an added extra, I've added submission of extra logging data, in order to enable more structured logging in the system. The extra data, such as tags, will be attached to 
```json
"values": [
    [ "<unix epoch in nanoseconds>", "<log line>", {"trace_id": "0242ac120002", "user_id": "superUser123"}]
]
```
Additionally, empty tags will be discarded. Previously you had positions like `exc_text=None`. They won't be sent now.

Please note that labels will be sent only using the V1 Loki protocol.